### PR TITLE
updated GH link in header

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -39,7 +39,7 @@ website:
             icon: "bug"
             href: "https://github.com/nhsengland/datascience-pd-newsletter/issues"
       - icon: github
-        href: https://github.com/nhsengland/
+        href: https://github.com/nhsengland/datascience-pd-newsletter
         aria-label: GitHub
 format:
   html:


### PR DESCRIPTION
From Bug picked up by Sam Hollings. GH logo now directs to this repo.